### PR TITLE
IANA actions to establish "co" ALPN

### DIFF
--- a/draft-lenders-core-dnr.md
+++ b/draft-lenders-core-dnr.md
@@ -287,8 +287,9 @@ TODO Security
 
 ## TLS ALPN for CoAP
 
-The TLS registration review team was asked to enter the following into the registry called
-TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs:
+The following entry is being requested for addition into the
+"TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs" registry,
+which is part of the "Transport Layer Security (TLS) Extensions" group.
 
 * Protocol: CoAP (over DTLS)
 * Identification sequence: 0x63 0x6f ("co")


### PR DESCRIPTION
This picks up https://mailarchive.ietf.org/arch/msg/tls-reg-review/meMm8LYSxvn4BGIkikScM3BblOw/ -- once that is out in a draft, we'll get the ALPN.

We don't need to worry about document normativity here, the registry is expert review only -- they just want *some* place that has text.

And spare us a round trip: Yes, this is a problem statement document. If you insist on problem-statement-ish text, that may be

> The problem is trival for the DTLS case, as illustrated in section IANA considerations – those lines and a mail to the list was all it took to just register it. For the non-transport layer security layers, we're writing all the rest of that text.

(Granted, the document might warrant a less flippant tone, but I hope it suffices to convince you that it does indeed fit in this document.)

This could go into literally any other related document as well, but this one is most suitable because for the time being, this is the only document that does something with it, even if it's just illustrative examples. If it turns out that our solutions document also covers part of the TLS case, there is nothing to stop us from moving the comment as the document is advanced, and asking the experts to update the reference.